### PR TITLE
Cleanup CI scripts after pixi 0.0.6 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,24 +38,10 @@ jobs:
     - name: Build
       shell: bash -l {0}
       run: | 
-        # As of pixi 0.0.5 the dependency does not work nicely
+        # As of pixi 0.0.6 the dependency does not work nicely
         pixi run build
         
     - name: Run
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
       run: | 
-        # pixi run onnx-cpp-benchmark --help
-        # manually running onnx-cpp-benchmark as a workaround for https://github.com/prefix-dev/pixi/issues/157
-        ./.build/onnx-cpp-benchmark --help
+        pixi run onnx-cpp-benchmark --help
  
-    # Workaround for https://github.com/prefix-dev/pixi/issues/157
-    - name: Setup for Run
-      if: contains(matrix.os, 'windows')
-      run: | 
-        "D:\a\onnx-cpp-benchmark\onnx-cpp-benchmark\.pixi\env\Library\bin" >> $env:GITHUB_PATH
-
-    - name: Run
-      if: contains(matrix.os, 'windows')
-      run: | 
-        cd .build
-        .\onnx-cpp-benchmark --help


### PR DESCRIPTION
Now pixi run should propagate correctly the exit status, see https://github.com/prefix-dev/pixi/issues/157 .